### PR TITLE
Update dvc.lock

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -1,2 +1,33 @@
 schema: '2.0'
-stages: {}
+stages:
+  download:
+    cmd: stages/01_download.sh
+    deps:
+    - path: stages/01_download.sh
+      hash: md5
+      md5: 57e52532791f311f0ad2a5dad3a5babb
+      size: 847
+    outs:
+    - path: download
+      hash: md5
+      md5: d751713988987e9331980363e24189ce.dir
+      size: 0
+      nfiles: 0
+    - path: list
+      hash: md5
+      md5: 226825f473393acae771b2c667b1519c.dir
+      size: 0
+      nfiles: 1
+  invalidate:
+    cmd: stages/00_invalidate_cache.sh
+    deps:
+    - path: stages/00_invalidate_cache.sh
+      hash: md5
+      md5: 307212003320f12935d53ed0cd70041b
+      size: 525
+    outs:
+    - path: list
+      hash: md5
+      md5: e6dc02c03f9c5d7b8d86b74a7f9d06ee.dir
+      size: 5405
+      nfiles: 1

--- a/stages/00_invalidate_cache.sh
+++ b/stages/00_invalidate_cache.sh
@@ -17,6 +17,6 @@ export URL='https://data.orthodb.org/v12/download/'
 
 # Retrieve the list of files to download from HTTP base address.
 # If this changes, then the downloads need to change.
-wget -P "$list" "$URL"
+wget -P "$list" -N "$URL"
 
-echo "Download done."
+echo "Download list cache done."


### PR DESCRIPTION
```
These are failing:
	odb12v0_gene_xrefs.tab.gz
		; python3 stages/csv2parquet.py download/odb12v0_gene_xrefs.tab.gz test0.tab.parquet
	odb12v0_genes.tab.gz
		; python3 stages/csv2parquet.py download/odb12v0_genes.tab.gz test1.tab.parquet
```
